### PR TITLE
Reference load fix develop

### DIFF
--- a/dataviewer/config.py
+++ b/dataviewer/config.py
@@ -136,7 +136,6 @@ def from_ini(filepath, ifo=None):
     basics = dict(cp.items('monitor', raw=True))
     type_ = basics.pop('type')
     channels = map(str, ChannelList.from_names(basics.pop('channels', '')))
-    references = basics.pop('references', None)
     combinations = basics.pop('combinations', None)
     basics = dict((key, safe_eval(val)) for (key, val) in basics.iteritems())
     # get type
@@ -149,9 +148,9 @@ def from_ini(filepath, ifo=None):
     if not channels:
         channels = [c for c in sections if c not in ['monitor', 'plot']
                     if c[:4] not in ['ref:', 'com:']]
-    if references is None:
-        references = [c for c in sections if c not in ['monitor', 'plot']
-                      if c[:4] == 'ref:']
+
+    references = [c for c in sections if c not in ['monitor', 'plot']
+                  if c[:4] == 'ref:']
     if combinations is None:
         combinations = [c for c in sections if c not in ['monitor', 'plot']
                         if c[:4] == 'com:']
@@ -176,44 +175,36 @@ def from_ini(filepath, ifo=None):
             cparams[param].append(val)
 
     # get reference parameters
+    # reference parameters will be sent to the monitor in a dictionary with the path
+    # of each reference as keys and with the name and the other parameters as a dictionary
+    # for each key
+
     rparams = OrderedDict()
     for reference in references:
-        if os.path.basename(reference[4:]) == '':
-            # Section is a directory:
-            # get parameters (will be applied to all refrences)
-            _params = cp.items(reference)
-            rparamsi = OrderedDict()
-            for param, val in _params:
-                val = safe_eval(val)
-                if param == 'format':
-                    refform = val
+        rparamsi = OrderedDict([('name', reference[4:])])
+        for param, val in cp.items(reference):
+            val = safe_eval(val)
+            if param == 'path':
+                refpath = val
+            else:
+                rparamsi[param] = val
+            try:
+                if os.path.isdir(refpath):
+                    # Section is a directory:
+                    # import all references in folder (assumes 'dat' format)
+                    for f in os.listdir(refpath):
+                        if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
+                            refpath += f
+                            rparamsi.setdefault(
+                                'label', os.path.basename(refpath).split('.')[0].replace('_', r' '))
+                            rparams[refpath] = rparamsi
+
                 else:
-                    rparamsi[param] = val
-            # import all references in folder (assumes 'dat' format)
-            refdir = reference[4:]
-            for f in os.listdir(refdir):
-                if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
-                    refspec = Spectrum.read(refdir + f)
-                    refspec.name = f.split('.')[0].replace('_', r' ')
-                    rparams[refspec] = rparamsi
-        else:
-            # get rerference section
-            _params = cp.items(reference)
-            refpath = reference[4:]
-            refform = 'txt'
-            deflabel = os.path.basename(refpath).split('.')[0]
-            rparamsi = OrderedDict([('label', deflabel)])
-            for param, val in _params:
-                val = safe_eval(val)
-                if param == 'path':
-                    refpath = val
-                elif param == 'format':
-                    refform = val
-                else:
-                    rparamsi[param] = val
-            # load curve
-            refspec = Spectrum.read(refpath, format=refform)
-            rparams[refspec] = rparamsi
+                    rparamsi.setdefault(
+                        'label', os.path.basename(refpath).split('.')[0].replace('_', r' '))
+                    rparams[refpath] = rparamsi
+            except NameError:
+                raise ValueError('Cannot load reference {0} plot if no parameter "path" is defined'.format(reference))
 
     # get combination parameters # IN PROGRESS
     combparams = OrderedDict()

--- a/dataviewer/config.py
+++ b/dataviewer/config.py
@@ -175,9 +175,9 @@ def from_ini(filepath, ifo=None):
             cparams[param].append(val)
 
     # get reference parameters
-    # reference parameters will be sent to the monitor in a dictionary with the path
-    # of each reference as keys and with the name and the other parameters as a dictionary
-    # for each key
+    # reference parameters will be sent to the monitor in a dictionary
+    #  with the path of each reference as keys and with the name and the other
+    # parameters as a dictionary for each key
 
     rparams = OrderedDict()
     for reference in references:
@@ -196,15 +196,19 @@ def from_ini(filepath, ifo=None):
                         if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
                             refpath += f
                             rparamsi.setdefault(
-                                'label', os.path.basename(refpath).split('.')[0].replace('_', r' '))
+                                'label', os.path.basename(refpath).split('.')
+                                [0].replace('_', r' '))
                             rparams[refpath] = rparamsi
 
                 else:
                     rparamsi.setdefault(
-                        'label', os.path.basename(refpath).split('.')[0].replace('_', r' '))
+                        'label', os.path.basename(refpath).split('.')[0]
+                            .replace('_', r' '))
                     rparams[refpath] = rparamsi
             except NameError:
-                raise ValueError('Cannot load reference {0} plot if no parameter "path" is defined'.format(reference))
+                raise ValueError('Cannot load reference {0} plot if no '
+                                 'parameter "path" is defined'
+                                 .format(reference))
 
     # get combination parameters # IN PROGRESS
     combparams = OrderedDict()

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -173,7 +173,7 @@ class NDSDataIterator(NDSDataSource):
             if e.message == 'Invalid channel name':
                 self.logger.error(
                     'Invalid channel name {0}'.format(self._unique_channel_names(self.channels)))
-                raise
+            raise
         self.logger.debug('NDSDataIterator ready')
         return self.iterator
 

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -172,7 +172,8 @@ class NDSDataIterator(NDSDataSource):
         except RuntimeError as e:
             if e.message == 'Invalid channel name':
                 self.logger.error(
-                    'Invalid channel name {0}'.format(self._unique_channel_names(self.channels)))
+                    'Invalid channel name {0}'.format(
+                        self._unique_channel_names(self.channels)))
             raise
         self.logger.debug('NDSDataIterator ready')
         return self.iterator

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -166,8 +166,14 @@ class NDSDataIterator(NDSDataSource):
         return self
 
     def start(self):
-        self.iterator = self.connection.iterate(
-            self.ndsstride, self._unique_channel_names(self.channels))
+        try:
+            self.iterator = self.connection.iterate(
+                self.ndsstride, self._unique_channel_names(self.channels))
+        except RuntimeError as e:
+            if e.message == 'Invalid channel name':
+                self.logger.error(
+                    'Invalid channel name {0}'.format(self._unique_channel_names(self.channels)))
+                raise
         self.logger.debug('NDSDataIterator ready')
         return self.iterator
 

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -132,10 +132,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             self._references[refparams['label']] = refparams
         elif isinstance(ref, dict):
             for key, val in ref.iteritems():
-                if 'format' in val:
-                    refspec = Spectrum.read(key, format=val.pop('format'))
-                else:
-                    refspec = Spectrum.read(key)
+                refspec = Spectrum.read(key, format=val.pop('format', None))
                 refspec.name = val.pop('name')
                 self.add_reference(refspec, **val)
 
@@ -368,7 +365,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             self.spectra[channel].__dict__ = (
                 SPECTRA[channel][0].copy_metadata())
             if channel.filter:
-                self.spectra[channel] = self.spectra[channel].filter(
+                self.spectra[channel] = self.spectra[channel].zpk(
                     *channel.filter)
             self.logger.debug('%s ASD recalculated for %s'
                               % (self.method, str(channel)))

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -82,7 +82,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         # add references
         self._references = OrderedDict()
         if 'reference' in kwargs:
-            self.add_reference(kwargs.pop('reference'))  #aaargh e se voglio dargli uno spettro nei kwargs perchè sono interattivo?
+            self.add_reference(kwargs.pop('reference'))
         # add combinations
         self.combinations = OrderedDict()
         if 'combination' in kwargs:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -234,7 +234,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             # channel and reference spectra
             cha_spec = dict((i, self.spectra[self.channels[i]]) for
                             i in cha_ids)
-            ref_spec = dict((i, self._references.keys()[i]) for i in ref_ids)
+            ref_spec = dict((i, self._references.values()[i]['spectrum']) for i in ref_ids)
 
             if self._flims is None:
                 # PREPARE CHANNELS

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -28,7 +28,7 @@ import numpy
 
 from astropy.time import Time
 
-from gwpy.plotter import (SpectrumPlot, SpectrumAxes, rcParams)
+from gwpy.plotter import (SpectrumPlot, SpectrumAxes)
 from gwpy.spectrum.core import Spectrum
 
 from . import version
@@ -78,7 +78,6 @@ class SpectrumMonitor(TimeSeriesMonitor):
         self.spectra = OrderedDict()
         self._flims = None
 
-
         # add references
         self._references = OrderedDict()
         if 'reference' in kwargs:
@@ -86,7 +85,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         # add combinations
         self.combinations = OrderedDict()
         if 'combination' in kwargs:
-             self.add_combination(kwargs.pop('combination'), channels)
+            self.add_combination(kwargs.pop('combination'))
 
         # parse filters
         filters = kwargs.pop('filters', kwargs.pop('filter', []))
@@ -143,9 +142,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         else:
             raise ValueError('Invalid reference syntax.')
 
-    def add_combination(self, combs, channels):
-
-        nch = len(channels)
+    def add_combination(self, combs):
 
         # parse combinations
         if combs is None:
@@ -187,7 +184,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         elif isinstance(combs, (list, tuple)):
             for c in combs:
                 if isinstance(c, basestring):
-                    self.combinations[self.parse_combination(c)] = {'label':c}
+                    self.combinations[self.parse_combination(c)] = {'label': c}
                 elif isinstance(c, tuple) and len(c) == 2:
                     k = combs[0]
                     v = combs[1]
@@ -223,8 +220,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
         try:
             ncha = len(self.channels)
-            if any([ci >= ncha for ci in cha_ids]) or any(
-                [ri >= nref for ri in ref_ids]):
+            if any([ci >= ncha for ci in cha_ids]) or\
+                    any([ri >= nref for ri in ref_ids]):
                 raise IndexError('Combination out of bounds.')
         except AttributeError:
             pass
@@ -419,7 +416,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
         self.logger.debug('Figure data updated')
         # add suptitle
-        if not 'suptitle' in self.params['init']:
+        if 'suptitle' not in self.params['init']:
             prefix = ('FFT length: %ss, Overlap: %ss, Averages: %d -- '
                       % (self.fftlength, self.overlap, self.averages))
             utc = re.sub('\.0+', '',
@@ -446,8 +443,8 @@ def parseparams(deflabel, param_in):
                     m = '.'
                 raise ValueError('Unsupported parameter %r for'
                                  'single line plotting%s' % (p, m))
-    elif isinstance(param_in, list)\
-    and all([isinstance(p, tuple) and len(p) == 2 for p in param_in]):
+    elif isinstance(param_in, list) \
+            and all([isinstance(p, tuple) and len(p) == 2 for p in param_in]):
         for (p, v) in param_in:
             if p in PARAMS['draw']+['label']:
                 param_out[p] = v

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -365,7 +365,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             self.spectra[channel].__dict__ = (
                 SPECTRA[channel][0].copy_metadata())
             if channel.filter:
-                self.spectra[channel] = self.spectra[channel].zpk(
+                self.spectra[channel] = self.spectra[channel].filter(
                     *channel.filter)
             self.logger.debug('%s ASD recalculated for %s'
                               % (self.method, str(channel)))

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -115,15 +115,15 @@ class SpectrumMonitor(TimeSeriesMonitor):
         ---------
         refs: `Spectrum`, `dict`, `tuple`, `list`
             Reference spectra. Can be:
-            - `Spectrum`: one single reference spectrum, label taken
+            -`Spectrum`: one single reference spectrum, label taken
             from name and needs to be unique
-            - 'dict': keys must be the path of the files containing the spectra,
+            -'dict': keys must be the path of the files containing the spectra,
             values must be dictionaries containing plot arguments, e.g.
                 refs = {'/path/to/file':{'label':'somelabel', ...}, ...}
-            - 'tuple': first element must be `Spectrum` object, second must be
+            -'tuple': first element must be `Spectrum` object, second must be
              dictionary containing plot arguments, e.g.
                 refs = ((refspectrum, {'color': 'r'}), ...)
-            - `list`: each element can be a `Spectrum` or a tuple following the
+            -'list`: each element can be a `Spectrum` or a tuple following the
             format outlined above.
         """
         if isinstance(ref, Spectrum):
@@ -234,7 +234,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
             # channel and reference spectra
             cha_spec = dict((i, self.spectra[self.channels[i]]) for
                             i in cha_ids)
-            ref_spec = dict((i, self._references.values()[i]['spectrum']) for i in ref_ids)
+            ref_spec = dict((i, self._references.values()[i]['spectrum'])
+                            for i in ref_ids)
 
             if self._flims is None:
                 # PREPARE CHANNELS
@@ -341,7 +342,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 fdata = new[channel].crop(fftepoch, fftepoch + self.fftlength)
                 fft = fdata.asd(self.fftlength, self.overlap, method=method,
                                 **self.window)
-                fft.epoch = fdata.epoch # is this really necessary? why doesn't the .asd method copy it?
+                # copy the epoch, necessary since .asd doesn't copy it yet
+                fft.epoch = fdata.epoch
                 self.logger.debug('%ds ASD calculated for %s'
                                   % (self.fftlength, str(channel)))
                 SPECTRA[channel] = (SPECTRA[channel] + [fft])[-self.averages:]
@@ -421,7 +423,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
             prefix = ('FFT length: %ss, Overlap: %ss, Averages: %d -- '
                       % (self.fftlength, self.overlap, self.averages))
             utc = re.sub('\.0+', '',
-                         Time(float(self.epoch), format='gps', scale='utc').iso)
+                         Time(float(self.epoch),
+                              format='gps', scale='utc').iso)
             suffix = 'Last updated: %s UTC (%s)' % (utc, self.epoch)
             self.suptitle = self._fig.suptitle(prefix + suffix)
         self.set_params('refresh')

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -113,7 +113,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
         Arguments
         ---------
-        refs: `Spectrum`, `tuple`, `list`
+        refs: `Spectrum`, `dict`, `tuple`, `list`
             Reference spectra. Can be:
             - `Spectrum`: one single reference spectrum, label taken
             from name and needs to be unique


### PR DESCRIPTION
This is the fix I made for the reference spectra loading, which was necessary since there were issues in using spectrum objects as keys in a dictionary.
Basically the changes are: 
- during the from_ini (n config.py) call now the references are not converted in spectra, and a dictionary is created with just the path of the reference files as key. This allows the user to use non-spectra references, just in case they could be useful for monitors other than the spectrum monitor (i.e. threshold lines in the timeseries monitor). I also removed the possibility of inserting the reference spectra in the [monitor] section of the .ini file since it seemed redundant to me. 
- I tried to keep the add_reference() method  (in spectrum.py) as much compatible with the previous one as possible.  The differences are: 
  1. if a dictionary is given to that function it now assumes that it is a dictionary of the type produced by the from_ini function. If instead a spectrum, a list or a tuple of spectrum objects is  given to that function, the behaviour of the function should be unchanged. 
  2. The output of the function is now a dictionary that uses the 'legend' attribute as keys (instead of the spectrum object) and a dictionary containing the spectrum and the spectrum parameters as values. I'm not very happy of this solution since the legend parameter is still kept in the values dictionary and the key value is therefore not used (see changes at line 289-291), but this still seemed to be the most simple way to solve the issue at that time. 
- In the pull request there also a small  change to the nds iterator start method, just to give the user a bit more information in case there are issues with the names of the channels. 

Let me know if you have in mind a 'cleaner' way to implement the reference spectra and if you would prefer changing some of the edits I made before merging. 
