### PR TITLE
Nds fail handling develop

### DIFF
--- a/dataviewer/__init__.py
+++ b/dataviewer/__init__.py
@@ -19,8 +19,6 @@
 """GWDV: The gravitational-wave data viewer
 """
 
-import nds2
-
 from . import version
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -246,7 +246,7 @@ class Monitor(TimedAnimation):
                         getattr(ax, 'set_%s' % key)(v)
             elif key in AXES_PARAMS:
                 if not (isinstance(val, (list, tuple)) and
-                        isinstance(val[0], (list, tuple))):
+                        isinstance(val[0], (list, tuple, basestring))):
                     val = [val] * len(self._fig.axes)
                 for ax, v in zip(self._fig.axes, val):
                     getattr(ax, 'set_%s' % key)(v)

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -70,7 +70,7 @@ class Monitor(TimedAnimation):
     # -------------------------------------------------------------------------
     # Initialise the figure
 
-    def __init__(self, fig=None, interval=1, blit=True, repeat=False,
+    def __init__(self, fig=None, interval=2, blit=True, repeat=False,
                  logger=Logger('monitor'), figname=None, save_every=1,
                  tight_bbox=False, pause=False, clock=False, **kwargs):
         self.logger = logger

--- a/dataviewer/data.py
+++ b/dataviewer/data.py
@@ -60,7 +60,7 @@ class DataMonitor(Monitor):
 
         # separate keyword arguments
         buffkeys = ['host', 'port', 'connection', 'interval', 'duration', 'pad',
-                    'gap']
+                    'gap', 'attempts']
         buffargs = {'logger': kwargs.get('logger')}
         for key in buffkeys:
             if key in kwargs:

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -226,13 +226,15 @@ class NDSDataIterator(NDSDataSource):
                             '%d, restarting building the buffer from %d ') \
                             % (epoch, ts.span[0], ts.span[0])
                         self.logger.warning(str(e))
-                        new = TimeSeriesDict((c, ts))
+                        new = TimeSeriesDict()
+                        new[c] = ts
                     elif 'starts before' in str(e):
                         e.message = (
                             'Overlap between old data and new data in the '
                             'nds buffer, only the new data will be kept.')
                         self.logger.warning(str(e))
-                        new = TimeSeriesDict((c, ts))
+                        new = TimeSeriesDict()
+                        new[c] = ts
                     else:
                         raise
                 span = abs(new[c].span)

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -152,14 +152,15 @@ class NDSDataIterator(NDSDataSource):
         super(NDSDataIterator, self).__init__(channels, host=host, port=port,
                                               connection=connection,
                                               logger=logger, **kwargs)
-        self.interval = interval
+
         if self.connection.get_protocol() == 1:
             ndsstride = 1
         else:
             ndsstride = int(ceil(min(interval, 10)))
+        self.duration = duration
+        self.interval = interval
         self.ndsstride = ndsstride
         self._duration = 0
-        self.duration = duration
         self.gap = gap
         self.pad = pad
         self.attempts = attempts
@@ -229,7 +230,6 @@ class NDSDataIterator(NDSDataSource):
                         continue
                     else:
                         raise
-                        # raise #butto via sti dati e ricomincio?
                 span = abs(new[c].span)
                 epoch = new[c].span[-1]
                 self.logger.debug('%ds data for %s received'

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -19,10 +19,9 @@
 """This module defines the `NDSDataBuffer`
 """
 
-import nds2
+
 
 from numpy import ceil
-from gwpy.detector import Channel
 from gwpy.io import nds as ndsio
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from fractions import gcd
@@ -32,7 +31,7 @@ from ..log import Logger
 from . import (register_data_source, register_data_iterator)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
+__version__ = version.version
 
 class NDSDataSource(object):
     """A data holder for fetching from NDS

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -164,6 +164,7 @@ class NDSDataIterator(NDSDataSource):
         self.gap = gap
         self.pad = pad
         self.attempts = attempts
+
         self.start()
 
     def __iter__(self):

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -157,10 +157,10 @@ class NDSDataIterator(NDSDataSource):
             ndsstride = 1
         else:
             ndsstride = int(ceil(min(interval, 10)))
-        self.duration = duration
         self.interval = interval
         self.ndsstride = ndsstride
-        self._duration = 0
+        self._duration = None
+        self.duration = duration
         self.gap = gap
         self.pad = pad
         self.attempts = attempts

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -25,6 +25,8 @@ from numpy import ceil
 from gwpy.io import nds as ndsio
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from fractions import gcd
+from time import sleep
+from gwpy.time import tconvert
 
 from .. import version
 from ..log import Logger
@@ -197,10 +199,14 @@ class NDSDataIterator(NDSDataSource):
                 self.logger.error('RuntimeError caught: %s' % str(e))
                 if attempts < self.max_attempts:
                     attempts += 1
+                    wait_time = attempts / 4 + 1
                     self.logger.warning(
                         'Attempting to reconnect to the nds server... {0}/{1}'
-                            .format(attempts, self.max_attempts))
+                        .format(attempts, self.max_attempts))
+                    self.logger.warning('Next attempt in minimum {0} seconds'
+                                        .format(wait_time))
                     self.restart()
+                    sleep(wait_time - tconvert('now') % wait_time)
                     continue
                 else:
                     self.logger.critical(

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -226,9 +226,13 @@ class NDSDataIterator(NDSDataSource):
                             '%d, restarting building the buffer from %d ') \
                             % (epoch, ts.span[0], ts.span[0])
                         self.logger.warning(str(e))
-                        new = TimeSeriesDict()
-                        span = 0
-                        continue
+                        new = TimeSeriesDict((c, ts))
+                    elif 'starts before' in str(e):
+                        e.message = (
+                            'Overlap between old data and new data in the '
+                            'nds buffer, only the new data will be kept.')
+                        self.logger.warning(str(e))
+                        new = TimeSeriesDict((c, ts))
                     else:
                         raise
                 span = abs(new[c].span)

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -228,7 +228,8 @@ class NDSDataIterator(NDSDataSource):
                         self.logger.warning(str(e))
                         new = TimeSeriesDict()
                         new[c] = ts.copy()
-                    elif 'starts before' in str(e):
+                    elif ('starts before' in str(e)) or \
+                            ('overlapping' in str(e)):
                         e.message = (
                             'Overlap between old data and new data in the '
                             'nds buffer, only the new data will be kept.')

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -227,14 +227,14 @@ class NDSDataIterator(NDSDataSource):
                             % (epoch, ts.span[0], ts.span[0])
                         self.logger.warning(str(e))
                         new = TimeSeriesDict()
-                        new[c] = ts
+                        new[c] = ts.copy()
                     elif 'starts before' in str(e):
                         e.message = (
                             'Overlap between old data and new data in the '
                             'nds buffer, only the new data will be kept.')
                         self.logger.warning(str(e))
                         new = TimeSeriesDict()
-                        new[c] = ts
+                        new[c] = ts.copy()
                     else:
                         raise
                 span = abs(new[c].span)

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -235,7 +235,7 @@ class SpectrogramMonitor(TimeSeriesMonitor):
             _new = TimeSeriesDict((key, val[0].crop(self.epoch, self.epoch +
                                                     self.stride))
                                   for key, val in new.iteritems())
-            self.logger.debug('Spectrogram calculated at epoch {0}'
+            self.logger.debug('Computing spectrogram from epoch {0}'
                               .format(self.epoch))
             self.spectrograms.append(
                 self.spectrograms.from_timeseriesdict(_new))

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -224,14 +224,19 @@ class SpectrogramMonitor(TimeSeriesMonitor):
             s = ('The available data starts at gps {0} '
                  'which. is after the end of the last spectrogram(gps {1})'
                  ': a segment is missing and will be skipped!')
-            self.logger.warning(s.format(new[self.channels[0]].span[0],
+            self.logger.warning(s.format(new[self.channels[0]][0].span[0],
                                          self.epoch))
+            self.epoch = new[self.channels[0]][0].span[0]
+        # be sure that the first cycle is syncronized with the buffer
+        if not self.spectrograms.data:
             self.epoch = new[self.channels[0]][0].span[0]
         while new[self.channels[0]][0].span[-1] >= (self.epoch + self.stride):
             # data buffer will return dict of 1-item lists, so reform to tsd
             _new = TimeSeriesDict((key, val[0].crop(self.epoch, self.epoch +
                                                     self.stride))
                                   for key, val in new.iteritems())
+            self.logger.debug('Spectrogram calculated at epoch {0}'
+                              .format(self.epoch))
             self.spectrograms.append(
                 self.spectrograms.from_timeseriesdict(_new))
             self.epoch += self.stride

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -229,9 +229,9 @@ class SpectrogramMonitor(TimeSeriesMonitor):
         if new[self.channels[0]][0].span[0] > self.epoch:
             s = ('The available data starts at gps %d '
                  'which. is after the end of the last spectrogram (gps %d)'
-                 ': a segment is missing and will be skipped!'
-                 % (new[self.channels[0]][0].span[0], self.epoch))
-            self.logger.warning(s)
+                 ': a segment is missing and will be skipped!')
+            self.logger.warning(s, (new[self.channels[0]][0].span[0],
+                                    self.epoch))
             self.epoch = new[self.channels[0]][0].span[0]
         # be sure that the first cycle is syncronized with the buffer
         if not self.spectrograms.data:
@@ -242,8 +242,8 @@ class SpectrogramMonitor(TimeSeriesMonitor):
             _new = TimeSeriesDict((key, val[0].crop(self.epoch, self.epoch +
                                                     self.stride))
                                   for key, val in new.iteritems())
-            self.logger.debug('Computing spectrogram from epoch %d'
-                              % self.epoch)
+            self.logger.debug('Computing spectrogram from epoch %d',
+                              self.epoch)
             self.spectrograms.append(
                 self.spectrograms.from_timeseriesdict(_new))
             self.epoch += self.stride

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -334,7 +334,15 @@ class SpectrumMonitor(TimeSeriesMonitor):
             except (KeyError, IndexError, AttributeError):
                 SPECTRA[channel] = []
                 fftepoch = new[channel].epoch.gps
-            data = new[channel].crop(start=fftepoch)
+
+            if new[channel].span[0] > fftepoch:
+                s = ('The available data starts at gps {0} '
+                     'which. is after the end of the last spectrogram(gps {1})'
+                     ': a segment is missing and will be skipped!')
+                self.logger.warning(s.format(new[channel].span[0], fftepoch))
+                fftepoch = new[channel].span[0]
+
+            data = new[channel].crop(start=fftepoch) #is this crop necessary? Which is the diff between epoch and span[0]?
             count = 0
             # calculate new FFTs
             while fftepoch + self.fftlength <= data.span[-1]:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -117,7 +117,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             Reference spectra. Can be:
             - `Spectrum`: one single reference spectrum, label taken
             from name and needs to be unique
-            - 'dict': keys must be the path of the files containing the spectra,
+            - 'dict':keys must be the path of the files containing the spectra,
             values must be dictionaries containing plot arguments, e.g.
                 refs = {'/path/to/file':{'label':'somelabel', ...}, ...}
             - 'tuple': first element must be `Spectrum` object, second must be
@@ -234,7 +234,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
             # channel and reference spectra
             cha_spec = dict((i, self.spectra[self.channels[i]]) for
                             i in cha_ids)
-            ref_spec = dict((i, self._references.values()[i]['spectrum']) for i in ref_ids)
+            ref_spec = dict((i, self._references.values()[i]['spectrum'])
+                            for i in ref_ids)
 
             if self._flims is None:
                 # PREPARE CHANNELS

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -338,7 +338,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
             if new[channel].span[0] > fftepoch:
                 s = ('The available data starts at gps {0} '
-                     'which. is after the end of the last spectrogram(gps {1})'
+                     'which. is after the end of the last spectrum(gps {1})'
                      ': a segment is missing and will be skipped!')
                 self.logger.warning(s.format(new[channel].span[0], fftepoch))
                 fftepoch = new[channel].span[0]

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -334,16 +334,16 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 fftepoch = new[channel].epoch.gps
 
             if new[channel].span[0] > fftepoch:
-                s = ('The available data starts at gps {0} '
-                     'which. is after the end of the last spectrum(gps {1})'
-                     ': a segment is missing and will be skipped!')
-                self.logger.warning(s.format(new[channel].span[0], fftepoch))
+                s = ('The available data starts at gps %d '
+                     'which. is after the end of the last spectrum(gps %d)'
+                     ': a segment is missing and will be skipped!'
+                     % (new[channel].span[0], fftepoch))
+                self.logger.warning(s)
                 fftepoch = new[channel].span[0]
 
-            data = new[channel].crop(start=fftepoch) #is this crop necessary? Which is the diff between epoch and span[0]?
             count = 0
             # calculate new FFTs
-            while fftepoch + self.fftlength <= data.span[-1]:
+            while fftepoch + self.fftlength <= new[channel].span[-1]:
                 fdata = new[channel].crop(fftepoch, fftepoch + self.fftlength)
                 fft = fdata.asd(self.fftlength, self.overlap, method=method,
                                 **self.window)
@@ -395,8 +395,9 @@ class SpectrumMonitor(TimeSeriesMonitor):
                             **pparams)
                 except ValueError as e:
                     if 'Data has no positive values' in str(e):
-                        e.args = (str(e) + ' Manually declaring the ylim will '
-                                           'prevent this from occuring.',)
+                        e.message = (str(e) +
+                                     ' Manually declaring the ylim will '
+                                     'prevent this from occurring.',)
                         raise
                 self.legend = ax.legend(**self.params['legend'])
             for comb, parameters in self.combinations.iteritems():

--- a/dataviewer/timeseries.py
+++ b/dataviewer/timeseries.py
@@ -138,8 +138,9 @@ class TimeSeriesMonitor(DataMonitor):
                 l = ax.plot(ts, label=label, **pparams)
                 ax.legend()
             else:
+                # TODO: remove .copy() as soon as copy=True is fixed in gwpy
                 ts = TimeSeries(line.get_ydata(), times=line.get_xdata(),
-                                copy=True).copy()  # the .copy() shouln't be necessary...
+                                copy=True).copy()
                 for t2 in self.buffer.get((ts.span[1], self.epoch), channel,
                                           fetch=False):
                     ts.append(t2, pad=self.buffer.pad, gap=self.buffer.gap)

--- a/dataviewer/timeseries.py
+++ b/dataviewer/timeseries.py
@@ -109,7 +109,7 @@ class TimeSeriesMonitor(DataMonitor):
     def duration(self, d):
         self.buffer.duration = d
 
-    def update_data(self, new, gap='pad', pad=nan):
+    def update_data(self, new):
         self.epoch = new[self.channels[0]].segments[-1][1]
 
     def refresh(self):
@@ -123,7 +123,7 @@ class TimeSeriesMonitor(DataMonitor):
                 # haven't plotted this channel before
                 ax = next(axes)
                 label = (hasattr(channel, 'label') and channel.label or
-                         channel.texname)
+                         channel.name)
                 pparams = {}
                 for key in params:
                     try:


### PR DESCRIPTION
**Warning:** This Pull request is based on a branch created from the same branch used for the pull request #5  so it contains the same changes + a lot of new ones. 
Most of the new changes included in this branch are changes I made in order to improve the behaviour of the monitor when the nds client fails to retrieve some data and also to reduce to the minimum the frequency of such fails.  After these changes, the overall stability of the tool (especially when it runs remotely) seems to be largely improved. 
Other minor changes are included, I will try to remember at least the most relevant ones. 
### Changes Summary (with respect to #5):
#### Nds2 error handling:
- **Reconnection:** Changes in the lines [190 - 191](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-7d5f9781bf7f017bc23b960ce0e458fcL190) are aimed at allowing dataviewer to reconnect and recreate the nds iterator without breaking the loop and subsequently failing to find the key in the "new" "TimeSeriesDict()"  corresponding to the channels whose data was not retrieved because the loop break. Now, after the reconnection is performed, an attempt to retreive the data from the new iterator is performed. In order not to continue in an infinite loop of reconnection and attempts of iteration if the nds2 server keeps not retrieving the data, I also added a limit to the maximum reconnection attempts which can be set in the .ini file, and also a timer between one attempt and another that gets slower with the number of attempts already performed. I'm not sure that this maximum attempt limit is really necessary, since the user can just kill the monitor in case it is needed. 
- **Discontiguous or Overlapping nds strides:** The data retrieved from the nds server is not always in strides as long as the interval of the monitor, so it is possible for it to retrieve more than one stride in each interval and then attach them. If the nds2 iterator failed retrieving the data between one of these retrieving and attaching cycle, and then the nds2 connection and iteration was re-estabilished and new data were retrieved, the .append method gave an error because of the discontiguity between the data retrieved before the reconnection and the new data and the dataviewer crashed. With the changes at line [200](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-7d5f9781bf7f017bc23b960ce0e458fcL200) instead, if there's such a discontiguity (or overlap), the "new" "TimeseriesDict() is recreated starting with the new data, dropping the old one. This allows the monitor to keep running, while leaving a blank space corresponding to the missing and dropped data. 
- **Channel not found (very minor change)**:  If during the creation of the nds iterator the exception 'invalid channel name' is raised, before exiting the program now prints an error message containing the requested channel list (see line [174](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-7d5f9781bf7f017bc23b960ce0e458fcR174)). Yes, one could just check the config file in order to check which were the requested channels, but sometime this error message was still useful to me in order to understand the issue faster. 
#### Changes in the ndsstride and buffer duration (this one is a bit more complex):

During the countless tests and failures of the nds2 connection, I noticed two issues: 
- **Maximum speed**: the monitor has troubles in keeping up with the online data if it runs at 1 second intervals, this happens mostly if using the timeseries monitor and no refresh interval is set in the config file. Therefore I just changed the default interval to two seconds, no big deal. Maybe it could be useful to force the interval to be at least two seconds, but I think that any user that forces it to be 1 second is aware of the issues he might encounter in doing so. 
-  **Maximum length**: The nds2 iterator has much more troubles in retrieving nds strides the longer they are. Therefore I put a hard limit of maximum 10 seconds of ndsstride. This limit then made necessary several other changes. Indeed, what happens if an interval longer than 10 seconds is required from the monitor? Due to the 10 seconds cap of the ndsstride, now the nds iterator approximates the interval to the smallest multiple of ndsstride which is larger than the required interval (i.e. if the monitor requires 15 seconds of data, the nds iterator retrieves 10 seconds of data two times for a total of 20 seconds of data). This created no  big issues in monitors like spectrum and timeseries, but requred changes in the spectrogram monitor since it previously calculated a stride of the spectrogram using all the data available from the buffer. Now instead it checks how much data is available and uses only the correct stride length. (See changes at line [226](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-774df2b2bf2eff22148385d75652dc48L226) of spectrogram.py) . Furthermore, since there could be a difference between the set refresh interval and the "real" interval (the smallest multiple of ndsstride which is larger than the required interval) and the data used in each computation by the monitor, the size of the buffer has to be changed. In particular, the minimum size that the buffer has to keep in order not to loose any data is  **real interval + required data - gcd(real interval , required data)**. As an example, if the spectrogram monitor wants to calculate 12 seconds strides, the real interval will be 20 seconds (ndsstride will be 10, therefore two ndsstrides are required in each interval), and the buffer will have to keep in memory at least 20 + 12 - 4 = 28 seconds of data, in order to account of the maximum possible mismatch between the used data and the retrieved data (of course, as soon as more than 24 seconds of unused data are in the buffer, the spectrogram calculates two strides in the same interval leading to the mismatch completely resetting every 60 seconds in the example above). In order to keep this in account, the self.duration of the buffer is now set with a property at line  [284](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-7d5f9781bf7f017bc23b960ce0e458fcR284) of nds.py 
#### Other changes:
- The [from_timeseriesdict()](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-774df2b2bf2eff22148385d75652dc48L81) method now correctly uses the windowing and the method set in the config file. 
- Now if vmin and vmax are not set in the ini file, the spectrogram uses the same autoscaled colormap limits for all the plotted spectrograms (if there are missing strides, there is more than one spectrogram, and, before the additions at line [290](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-774df2b2bf2eff22148385d75652dc48R290) if vmin and vmax were not manually set, every one of these spectrograms had a different colormap but only one was referenced in the colorbar)
- If the label for a channel is not automatically provided, instead of setting it with channel.texname, now just uses channel.name, since it seems that the conversion into latex (by adding ) is no longer necessary in order to display the underscores in the name correctly. 
- At line [249](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:nds_fail_handling_develop?expand=1#diff-da20275dbd8a3a63d0b28d156ae2e010R249) of core.py, the set_param method now also accepts tuples of strings as axis parameters, in order to allow to set different xscale or yscale for different axes. 
