### PR TITLE
Various fixes

### DIFF
--- a/bin/gwdv
+++ b/bin/gwdv
@@ -67,6 +67,10 @@ if args.no_latex:
 
 mon = from_ini(args.configuration)
 mon.logger.setLevel(args.verbose)
+try:  # todo: put all the logger of all the monitors to the level?
+    mon.spectrograms.logger.setLevel(args.verbose)
+except AttributeError:
+    pass
 try:
     if args.back_fill:
         mon.backfill()

--- a/bin/gwdv
+++ b/bin/gwdv
@@ -68,6 +68,7 @@ if args.no_latex:
 mon = from_ini(args.configuration)
 mon.logger.setLevel(args.verbose)
 try:  # todo: put all the logger of all the monitors to the level?
+    mon.buffer.logger.setLevel(args.verbose)
     mon.spectrograms.logger.setLevel(args.verbose)
 except AttributeError:
     pass

--- a/dataviewer/config.py
+++ b/dataviewer/config.py
@@ -170,9 +170,10 @@ def from_ini(filepath, ifo=None):
             val = safe_eval(val)
             if param not in cparams:
                 cparams[param] = []
-            while len(cparams[param]) < i:
+            while len(cparams[param]) < len(channels):
                 cparams[param].append(None)
-            cparams[param].append(val)
+            cparams[param][i] = val
+
 
     # get reference parameters
     # reference parameters will be sent to the monitor in a dictionary

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -242,16 +242,34 @@ class Monitor(TimedAnimation):
                     if not isinstance(val, (list, tuple)):
                         val = [val] * len(self._fig.axes)
                     for ax, v in izip_longest(self._fig.axes, val):
-                        getattr(ax, 'set_%s' % key)(v)
+                        try:
+                            getattr(ax, 'set_%s' % key)(v)
+                        except ValueError as e:
+                            if 'too many values to unpack' in e:
+                                getattr(ax, 'set_%s' % key)(*v)
+                            else:
+                                raise
             elif key in AXES_PARAMS:
                 if not (isinstance(val, (list, tuple)) and
                         isinstance(val[0], (list, tuple, basestring))):
                     val = [val] * len(self._fig.axes)
                 for ax, v in zip(self._fig.axes, val):
-                    getattr(ax, 'set_%s' % key)(v)
+                    try:
+                        getattr(ax, 'set_%s' % key)(v)
+                    except ValueError as e:
+                        if 'too many values to unpack' in e:
+                            getattr(ax, 'set_%s' % key)(*v)
+                        else:
+                            raise
             else:
                 for ax in self._fig.axes:
-                    getattr(ax, 'set_%s' % key)(val)
+                    try:
+                        getattr(ax, 'set_%s' % key)(val)
+                    except ValueError as e:
+                        if 'too many values to unpack' in e:
+                            getattr(ax, 'set_%s' % key)(*val)
+                        else:
+                            raise
 
     # -------------------------------------------------------------------------
     # Event connections

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -49,7 +49,7 @@ BTN_HEIGHT = 0.05
 PARAMS = {}
 PARAMS['figure'] = ['figsize']
 PARAMS['init'] = ['title', 'xlabel', 'ylabel', 'xscale', 'yscale']
-PARAMS['draw'] = ['marker', 'linestyle', 'linewidth', 'linesize', 'markersize',
+PARAMS['draw'] = ['marker', 'linestyle', 'linewidth', 'markersize',
                   'color', 'alpha', 'norm', 'vmin', 'vmax', 'cmap']
 PARAMS['refresh'] = ['xlim', 'ylim']
 PARAMS['legend'] = ['bbox_to_anchor', 'loc', 'borderaxespad', 'ncol']

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -57,7 +57,7 @@ PARAMS['legend'] = ['bbox_to_anchor', 'loc', 'borderaxespad', 'ncol']
 PARAMS['colorbar'] = ['log', 'clim', 'label']
 
 FIGURE_PARAMS = ['title', 'subtitle']
-AXES_PARAMS = ['xlim', 'ylim', 'xlabel', 'ylabel']
+AXES_PARAMS = ['xlim', 'ylim', 'xlabel', 'ylabel', 'xscale', 'yscale']
 
 
 
@@ -85,7 +85,7 @@ class Monitor(TimedAnimation):
             fig = self.init_figure()
         # generate monitor
         self.interval = interval
-        super(Monitor, self).__init__(fig, interval=int(interval * 1000),
+        super(Monitor, self).__init__(fig, interval=int(100),
                                       blit=blit, repeat=repeat, **kwargs)
 
         self.figname = figname

--- a/dataviewer/core.py
+++ b/dataviewer/core.py
@@ -48,15 +48,14 @@ BTN_HEIGHT = 0.05
 # fixed parameters
 PARAMS = {}
 PARAMS['figure'] = ['figsize']
-PARAMS['init'] = ['title', 'subtitle', 'xlabel', 'ylabel', 'xscale', 'yscale',
-                  'suptitle']
+PARAMS['init'] = ['title', 'xlabel', 'ylabel', 'xscale', 'yscale']
 PARAMS['draw'] = ['marker', 'linestyle', 'linewidth', 'linesize', 'markersize',
                   'color', 'alpha', 'norm', 'vmin', 'vmax', 'cmap']
 PARAMS['refresh'] = ['xlim', 'ylim']
 PARAMS['legend'] = ['bbox_to_anchor', 'loc', 'borderaxespad', 'ncol']
 PARAMS['colorbar'] = ['log', 'clim', 'label']
 
-FIGURE_PARAMS = ['title', 'subtitle']
+FIGURE_PARAMS = ['title']
 AXES_PARAMS = ['xlim', 'ylim', 'xlabel', 'ylabel', 'xscale', 'yscale']
 
 

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -201,7 +201,7 @@ class NDSDataIterator(NDSDataSource):
                 self.logger.error('RuntimeError caught: %s' % str(e))
                 if att < self.attempts:
                     att += 1
-                    wait_time = att / 4 + 1
+                    wait_time = att / 3 + 1
                     self.logger.warning(
                         'Attempting to reconnect to the nds server... %d/%d'
                         % (att, self.attempts))

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -214,9 +214,13 @@ class SpectrogramMonitor(TimeSeriesMonitor):
 
         for _ in range(len(self.channels)):
             _new_axes()
-        for ax in self._fig.get_axes(self.AXES_CLASS.name)[:-1]:
-            ax.set_xlabel('')
         self.set_params('init')
+        for i, ax in enumerate(self._fig.get_axes(self.AXES_CLASS.name)):
+            if i != (len(self._fig.get_axes(self.AXES_CLASS.name)) - 1):
+                ax.set_xlabel('')
+            if i != 0:
+                ax.set_title('')
+
         self.set_params('refresh')
         return self._fig
 

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -230,8 +230,8 @@ class SpectrogramMonitor(TimeSeriesMonitor):
             s = ('The available data starts at gps %d '
                  'which. is after the end of the last spectrogram (gps %d)'
                  ': a segment is missing and will be skipped!')
-            self.logger.warning(s, (new[self.channels[0]][0].span[0],
-                                    self.epoch))
+            self.logger.warning(s, new[self.channels[0]][0].span[0],
+                                self.epoch)
             self.epoch = new[self.channels[0]][0].span[0]
         # be sure that the first cycle is syncronized with the buffer
         if not self.spectrograms.data:
@@ -294,12 +294,12 @@ class SpectrogramMonitor(TimeSeriesMonitor):
                 coloraxes[i]
             except IndexError:
                 cbparams = {}
-                for key in self.params['colorbar']:
-                    try:
-                        if self.params['colorbar'][key][i]:
-                            cbparams[key] = self.params['colorbar'][key][i]
-                    except IndexError:
-                        pass
+                for key, val in self.params['colorbar'].iteritems():
+                    if not (isinstance(val, (list, tuple)) and
+                                isinstance(val[0], (list, tuple, basestring))):
+                        cbparams[key] = self.params['colorbar'][key]
+                    else:
+                        cbparams[key] = self.params['colorbar'][key][i]
                 try:
                     self._fig.add_colorbar(mappable=coll, ax=ax, **cbparams)
                 except Exception as e:

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -241,7 +241,8 @@ class SpectrogramMonitor(TimeSeriesMonitor):
         if not self.spectrograms.data:
             self.epoch = new[self.channels[0]][0].span[0]
         self.olepoch = self.epoch
-        while new[self.channels[0]][0].span[-1] >= (self.epoch + self.stride):
+        while int(new[self.channels[0]][0].span[-1]) >=\
+                int(self.epoch + self.stride):
             # data buffer will return dict of 1-item lists, so reform to tsd
             _new = TimeSeriesDict((key, val[0].crop(self.epoch, self.epoch +
                                                     self.stride))

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -348,7 +348,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
             count = 0
             # calculate new FFTs
-            while fftepoch + self.fftlength <= new[channel].span[-1]:
+            while int(fftepoch + self.fftlength) <= int(new[channel].span[-1]):
                 fdata = new[channel].crop(fftepoch, fftepoch + self.fftlength)
                 fft = fdata.asd(self.fftlength, self.overlap, method=method,
                                 **self.window)

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -282,7 +282,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         def _new_axes():
             ax = self._fig._add_new_axes(self._fig._DefaultAxesClass.name)
             for _, plotparams in self._references.iteritems():
-                ppms = plotparams
+                ppms = plotparams.copy()
                 spec = ppms.pop('spectrum')
                 ax.plot(spec, **ppms)
                 self.legend = ax.legend(**self.params['legend'])

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -307,8 +307,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 ax.grid('on', 'both', 'x')
             if ax.get_yscale() == 'log':
                 ax.grid('on', 'both', 'y')
-
-        self._fig.add_colorbar(visible=False)
+            self._fig.add_colorbar(visible=False)
         return self._fig
 
     def update_data(self, new, gap='pad', pad=0):

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -307,7 +307,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 ax.grid('on', 'both', 'x')
             if ax.get_yscale() == 'log':
                 ax.grid('on', 'both', 'y')
-            self._fig.add_colorbar(visible=False)
+            self._fig.add_colorbar(visible=False, ax=ax)
         return self._fig
 
     def update_data(self, new, gap='pad', pad=0):

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -246,8 +246,8 @@ class SpectrumMonitor(TimeSeriesMonitor):
                     df = ref_spec.values()[0].df.value
 
                 for spec in cha_spec.values() + ref_spec.values():
-                    fmin = max(fmin, spec.span.start)
-                    fmax = min(fmax, spec.span.end)
+                    fmin = max(fmin, spec.xspan.start)
+                    fmax = min(fmax, spec.xspan.end)
                     if abs(spec.df.value - df) > df_tolerance:
                         raise CombinationError('Cannot operate on spectra with'
                                                ' different df')

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -282,18 +282,24 @@ class SpectrumMonitor(TimeSeriesMonitor):
         def _new_axes():
             ax = self._fig._add_new_axes(self._fig._DefaultAxesClass.name)
             for _, plotparams in self._references.iteritems():
-                spec = plotparams.pop('spectrum')
-                ax.plot(spec, **plotparams)
+                ppms = plotparams
+                spec = ppms.pop('spectrum')
+                ax.plot(spec, **ppms)
                 self.legend = ax.legend(**self.params['legend'])
 
         if self.sep:
             for n in range(len(self.channels) + len(self.combinations)):
                 _new_axes()
-            for ax in self._fig.get_axes(self.AXES_CLASS.name)[:-1]:
-                ax.set_xlabel('')
         else:
             _new_axes()
         self.set_params('init')
+        # remove repeated titles and xlabels
+        for i, ax in enumerate(self._fig.get_axes(self.AXES_CLASS.name)):
+            if i != (len(self._fig.get_axes(self.AXES_CLASS.name)) - 1):
+                ax.set_xlabel('')
+            if i != 0:
+                ax.set_title('')
+
         self.set_params('refresh')
         # set grids
         for ax in self._fig.axes:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -361,7 +361,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 count += 1
             if count == 0:
                 return
-            # calculated new average
+            # calculate new average
             if self.method == 'median-mean' and len(SPECTRA[channel]) == 1:
                 spec = SPECTRA[channel][0].value
             elif self.method == 'median-mean':

--- a/dataviewer/timeseries.py
+++ b/dataviewer/timeseries.py
@@ -23,7 +23,7 @@ from itertools import cycle
 
 from numpy import nan
 
-from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
+from gwpy.timeseries import (TimeSeries)
 from gwpy.plotter import (TimeSeriesPlot, TimeSeriesAxes)
 
 from . import version
@@ -85,16 +85,21 @@ class TimeSeriesMonitor(DataMonitor):
         if self.sep:
             for channel in self.channels:
                 _new_axes()
-            for ax in self._fig.get_axes(self.AXES_CLASS.name)[:-1]:
-                ax.set_xlabel('')
         else:
             _new_axes()
         self.set_params('init')
+        # remove repeated titles and xlabels
+        for i, ax in enumerate(self._fig.get_axes(self.AXES_CLASS.name)):
+            if i != (len(self._fig.get_axes(self.AXES_CLASS.name)) - 1):
+                ax.set_xlabel('')
+            if i != 0:
+                ax.set_title('')
+
         self.set_params('refresh')
         for ax in self._fig.axes:
             if ax.get_yscale() == 'log':
                 ax.grid(True, 'minor', 'y')
-        self._fig.add_colorbar(visible=False)
+            self._fig.add_colorbar(visible=False, ax=ax)
         return self._fig
 
     @property
@@ -123,7 +128,7 @@ class TimeSeriesMonitor(DataMonitor):
                 # haven't plotted this channel before
                 ax = next(axes)
                 label = (hasattr(channel, 'label') and channel.label or
-                         channel.name)
+                         channel.texname)
                 pparams = {}
                 for key in params:
                     try:


### PR DESCRIPTION
Hi, this pull is comprised of mostly self explanatory bug fixes, most of them came out when trying to use combinations or to plot things in multiple subplots, just wanted to note a couple of things:
- I changed the interval of the TimedAnimation to a fixed 100 ms in [core.py](https://github.com/gwpy/dataviewer/compare/gwpy-workarounds...mikelovskij:various_fixes#diff-da20275dbd8a3a63d0b28d156ae2e010L88). The real refresh interval of the monitor depends anyway on the retrieval of the data from the nds buffer, since the data retrieved is equal or larger than self.interval. Setting the TimedAnimation interval to this low amount seems to decrease a lot the time spent between the image refresh and the acquisition of the new data, allowing the monitors to catch up to the online data if they have fallen behind. 
- In all the monitors, some fixes were performed in order to remove correctly additional titles and xlabels, and to add an invisible colorbar for all axes in the case the channels are plotted in separate subplots. 
- I noticed that the usage of channel.texname instead of channel.name for the labels that I reputed superfluous is not superfluous at all (after I re-installed latex on my laptop), therefore I reintroduced it. I'm still not sure of why I didn't need it before, but it seems that matplotlib has different ways of rendering the text depending on the environment in which is ran.  
