### PR TITLE
Legend channelnames fix

### DIFF
--- a/bin/gwdv
+++ b/bin/gwdv
@@ -19,9 +19,7 @@
 
 """Start a new monitor using the GWpy DataViewer toolkit.
 
-Monitors should be configured in INI-format, see the package documention at
-
-https://gwpy.github.io/dataviewer/
+Monitors should be configured in INI-format.
 
 for details.
 """

--- a/bin/gwdv
+++ b/bin/gwdv
@@ -20,8 +20,6 @@
 """Start a new monitor using the GWpy DataViewer toolkit.
 
 Monitors should be configured in INI-format.
-
-for details.
 """
 
 from argparse import ArgumentParser

--- a/dataviewer/config.py
+++ b/dataviewer/config.py
@@ -194,7 +194,8 @@ def from_ini(filepath, ifo=None):
                 # Section is a directory:
                 # import all references in folder (assumes 'dat' format)
                 for f in os.listdir(refpath):
-                    if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
+                    if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz',
+                                                  '.hdf5', '.csv']:
                         refpath_f = refpath + '/' + f
                         rparamsi['label'] = os.path.basename(refpath_f).split(
                             '.')[0].replace('_', r' ')

--- a/dataviewer/config.py
+++ b/dataviewer/config.py
@@ -189,27 +189,26 @@ def from_ini(filepath, ifo=None):
                 refpath = val
             else:
                 rparamsi[param] = val
-            try:
-                if os.path.isdir(refpath):
-                    # Section is a directory:
-                    # import all references in folder (assumes 'dat' format)
-                    for f in os.listdir(refpath):
-                        if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
-                            refpath += f
-                            rparamsi.setdefault(
-                                'label', os.path.basename(refpath).split('.')
-                                [0].replace('_', r' '))
-                            rparams[refpath] = rparamsi
+        try:
+            if os.path.isdir(refpath):
+                # Section is a directory:
+                # import all references in folder (assumes 'dat' format)
+                for f in os.listdir(refpath):
+                    if os.path.splitext(f)[1] in ['.txt', '.dat', '.gz']:
+                        refpath_f = refpath + '/' + f
+                        rparamsi['label'] = os.path.basename(refpath_f).split(
+                            '.')[0].replace('_', r' ')
+                        rparams[refpath_f] = rparamsi.copy()
 
-                else:
-                    rparamsi.setdefault(
-                        'label', os.path.basename(refpath).split('.')[0]
-                            .replace('_', r' '))
-                    rparams[refpath] = rparamsi
-            except NameError:
-                raise ValueError('Cannot load reference {0} plot if no '
-                                 'parameter "path" is defined'
-                                 .format(reference))
+            else:
+                rparamsi.setdefault(
+                    'label', os.path.basename(refpath).split('.')[0]
+                        .replace('_', r' '))
+                rparams[refpath] = rparamsi
+        except NameError:
+            raise ValueError('Cannot load reference {0} plot if no '
+                             'parameter "path" is defined'
+                             .format(reference))
 
     # get combination parameters # IN PROGRESS
     combparams = OrderedDict()

--- a/dataviewer/source/nds.py
+++ b/dataviewer/source/nds.py
@@ -207,8 +207,8 @@ class NDSDataIterator(NDSDataSource):
                         % (att, self.attempts))
                     self.logger.warning('Next attempt in minimum %d seconds' %
                                         wait_time)
-                    self.restart()
                     sleep(wait_time - tconvert('now') % wait_time)
+                    self.restart()
                     continue
                 else:
                     self.logger.critical(

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -165,6 +165,7 @@ class SpectrogramMonitor(TimeSeriesMonitor):
         self.stride = stride
         self.overlap = overlap
         self.olepoch = None
+        self.temp_epoch = None
         # build monitor
         kwargs.setdefault('yscale', 'log')
         kwargs.setdefault('gap', 'raise')
@@ -239,7 +240,10 @@ class SpectrogramMonitor(TimeSeriesMonitor):
         # be sure that the first cycle is syncronized with the buffer
         if not self.spectrograms.data:
             self.epoch = new[self.channels[0]][0].span[0]
-        self.olepoch = self.epoch
+        if self.temp_epoch:
+            self.olepoch = self.temp_epoch
+        else:
+            self.olepoch = self.epoch  # todo: is this if/else necessary?
         while int(new[self.channels[0]][0].span[-1]) >=\
                 int(self.epoch + self.stride):
             # data buffer will return dict of 1-item lists, so reform to tsd
@@ -263,6 +267,7 @@ class SpectrogramMonitor(TimeSeriesMonitor):
                         self.spectrograms.data[channel][i].ratio(
                             channel.ratio))
         self.epoch = self.data[self.channels[0]][-1].span[-1]
+        self.temp_epoch = self.epoch
         return self.data
 
     def refresh(self):

--- a/dataviewer/spectrogram.py
+++ b/dataviewer/spectrogram.py
@@ -286,7 +286,7 @@ class SpectrogramMonitor(TimeSeriesMonitor):
 
         self.logger.debug('Figure data updated')
         # add suptitle
-        if not 'suptitle' in self.params['init']:
+        if 'suptitle' not in self.params['init']:
             prefix = ('FFT length: %ss, Overlap: %ss, Stride: %ss -- '
                       % (self.fftlength, self.overlap, self.stride))
             utc = re.sub('\.0+', '',

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -391,6 +391,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
         if len(lines) == 0:
             axes = cycle(self._fig.get_axes(self.AXES_CLASS.name))
             params = self.params['draw']
+            print params
             for i, channel in enumerate(self.spectra):
                 ax = next(axes)
                 try:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -112,18 +112,20 @@ class SpectrumMonitor(TimeSeriesMonitor):
 
         Arguments
         ---------
-        refs: `Spectrum`, `dict`, `tuple`, `list`
+        ref: `Spectrum`, `dict`, `tuple`, `list`
             Reference spectra. Can be:
-            -`Spectrum`: one single reference spectrum, label taken
-            from name and needs to be unique
+            -`Spectrum`: one single reference spectrum, its label is taken
+            from its .name attribute and needs to be unique.
             -'dict': keys must be the path of the files containing the spectra,
             values must be dictionaries containing plot arguments, e.g.
-                refs = {'/path/to/file':{'label':'somelabel', ...}, ...}
-            -'tuple': first element must be `Spectrum` object, second must be
-             dictionary containing plot arguments, e.g.
-                refs = ((refspectrum, {'color': 'r'}), ...)
-            -'list`: each element can be a `Spectrum` or a tuple following the
-            format outlined above.
+                ref = {'/path/to/file':{'label':'somelabel', ...}, ...}
+            -'tuple': Each element of the tuple has to be a valid argument for
+            this method, i.e. a dict or a Spectrum object like the ones
+            outlined above e.g.:
+                ref = ((refspectrum, {'color': 'r'}), ...)
+            -'list`: treated the same as a tuple argument.
+        **refparams: dictionary containing additional reference arguments, used
+         only if ref is a Spectrum object.
         """
         if isinstance(ref, Spectrum):
             refparams.setdefault('label', ref.name)

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -392,7 +392,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
             axes = cycle(self._fig.get_axes(self.AXES_CLASS.name))
             params = self.params['draw']
             print params
-            for i, channel in enumerate(self.spectra):
+            for i, channel in enumerate(self.channels):
                 ax = next(axes)
                 try:
                     pparams = dict((key, params[key][i]) for key in params if

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -391,13 +391,11 @@ class SpectrumMonitor(TimeSeriesMonitor):
         if len(lines) == 0:
             axes = cycle(self._fig.get_axes(self.AXES_CLASS.name))
             params = self.params['draw']
-            print params
             for i, channel in enumerate(self.channels):
                 ax = next(axes)
                 try:
                     pparams = dict((key, params[key][i]) for key in params if
                                    params[key][i])
-                    print pparams
                     ax.plot(self.spectra[channel], label=channel.label,
                             **pparams)
                 except ValueError as e:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -397,6 +397,7 @@ class SpectrumMonitor(TimeSeriesMonitor):
                 try:
                     pparams = dict((key, params[key][i]) for key in params if
                                    params[key][i])
+                    print pparams
                     ax.plot(self.spectra[channel], label=channel.label,
                             **pparams)
                 except ValueError as e:

--- a/dataviewer/spectrum.py
+++ b/dataviewer/spectrum.py
@@ -145,6 +145,38 @@ class SpectrumMonitor(TimeSeriesMonitor):
             raise ValueError('Invalid reference syntax.')
 
     def add_combination(self, combs):
+        """
+        Adds combinations between channels or references to the plot.
+
+        combs: `basestring`, `dict`, `tuple`, `list`
+                Combination, can be expressed as:
+                -'basestring' : directly represents a combination, e.g.:
+                    'C0 + R1' represents the sum between the first plotted
+                    channel and the second reference spectra.
+                -'dict' : dictionary with `basestring` as keys and
+                    a `basestring` or another `dict` as values. If a value is a
+                    `basestring`, it will be considered the combination string
+                    and its key will be used as label. If a value is a `dict`,
+                    the key will be used instead as the combination string,
+                    while the dictionary parameters will be parsed by the
+                    parseparams function and used as plotting parameters for
+                    the combination.
+                - 'tuple' : tuple. The tuple will be interpreted differently
+                    depending on its length and content. If the tuple has two
+                    elements and its first element is a `basestring` and the
+                    second element is a `basestring` too, the first element
+                    will be considered the label of the combination while the
+                    second, the combination string itself. If the tuple has two
+                    elements and its first element is a `basestring` but the
+                    second element is a dictionary, the first element will be
+                    used as the combination string while the dictionary will be
+                    parsed by the parseparam function and added to the
+                    combination plotting parameters.
+                    If the tuple has a number of elements different from two
+                    (or has two but the first is not a `basestring`), each
+                    element of the tuple will be evaluated independently, as
+                    long as it fits one of the cases explained above.
+        """
 
         # parse combinations
         if combs is None:

--- a/dataviewer/timeseries.py
+++ b/dataviewer/timeseries.py
@@ -20,7 +20,8 @@
 """
 
 from itertools import cycle
-
+import re
+from astropy.time import Time
 from numpy import nan
 
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
@@ -147,6 +148,12 @@ class TimeSeriesMonitor(DataMonitor):
                 line.set_ydata(ts.value)
 
         # format figure
+        if 'suptitle' not in self.params['init']:
+            prefix = ('Update interval: {0} -- '.format(self.interval))
+            utc = re.sub('\.0+', '',
+                         Time(self.epoch, format='gps', scale='utc').iso)
+            suffix = 'Last updated: %s UTC (%s)' % (utc, self.epoch)
+            self.suptitle = self._fig.suptitle(prefix + suffix)
         if 'ylim' not in self.params['refresh']:
             for ax in self._fig.get_axes(self.AXES_CLASS.name):
                 ax.relim()


### PR DESCRIPTION
Just some minor fixes:
- Moved the wait time between one reconnection attempt and the other before the restart method, in order to use the re-created iterator just after its creation, since waiting between the creation of the object and the first iteration seems (especially if the wait is more than 30 second) to increase the possibility of failing to retrieve the data.
- If vmin and vmax are not set and the colormap of a spectrogram changes due to an autoscale during the plotting, now the colorbar changes accordingly.
- Solved a weird issue in the spectrum monitor: it happened that the first time the spectra were plotted, they were plotted in the wrong order, leading to wrong colors with respect to the ones set in the config file. After the first iteration, the spectra would have been replotted in the correct way, but the legend not, keeping the wrong colors. By changing the iterator from self.spectra to self.channels now the spectra are plotted in the correct order since the first iteration and the legend is created correctly.
- Added the suptitle (with the plotting time) to the timeseries monitor. 
